### PR TITLE
feat: add no-ai extract and paraglide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,26 @@
 
 **i18nizer automates the boring parts of i18n.**
 
-If your project already uses **i18next** or **next-intl**, i18nizer:
+If your project already uses **i18next**, **next-intl**, or **Paraglide JS**, i18nizer:
 
 - extracts hardcoded strings from JSX/TSX
-- generates i18n JSON files using **AI-assisted translations**
-- creates readable English keys (**AI-powered & cached**)
-- rewrites your components to use `t("key")`
+- can extract source messages **without AI**
+- can generate translated JSON files using **AI-assisted translations**
+- creates readable keys with deterministic fallback
+- rewrites your components to use `t("key")` or `m.key_name()`
 
 No runtime, no lock-in, no SaaS.  
 Just a CLI that fits into your existing development workflow.
 
 ## 🤖 How translations work
 
-i18nizer uses AI providers (OpenAI, Gemini, Hugging Face) to generate translations
-at development time.
+i18nizer can use AI providers (OpenAI, Gemini, Hugging Face) to generate
+translations at development time.
 
 - Translations are generated once and stored as plain JSON files
 - Output is fully editable and version-controlled
+- `extract` does not require AI
+- `translate --dry-run` does not require AI
 - No AI is required at runtime
 - Cached translations avoid repeated AI requests
 
@@ -39,7 +42,7 @@ You own the result — i18nizer only automates the process.
 
 ## Who is this for?
 
-- React / Next.js developers already using i18next or next-intl
+- React / Next.js developers already using i18next, next-intl, or Paraglide JS
 - Teams tired of manually extracting strings and managing i18n JSONs
 - Projects that want automation without changing runtime behavior
 
@@ -60,6 +63,19 @@ npm install -g i18nizer
 ```
 
 > Requires Node.js 18+
+
+### Use from a local source checkout
+
+If you want to run the CLI from this repository while developing locally:
+
+```bash
+corepack yarn install
+corepack yarn build
+npm link
+i18nizer --help
+```
+
+`npm link` exposes the `i18nizer` command from your local checkout. If you change the source, run `corepack yarn build` again before using the linked binary.
 
 ---
 
@@ -92,7 +108,7 @@ i18nizer start
 This launches an **interactive setup** that will:
 
 - 🔍 Auto-detect your framework (Next.js or React)
-- 🔍 Auto-detect your i18n library (next-intl, react-i18next, i18next)
+- 🔍 Auto-detect your i18n library (next-intl, react-i18next, i18next, paraglide-js)
 - ❓ Ask you to confirm or change the detected settings
 - ✅ Create `i18nizer.config.yml` with optimal defaults
 - 📁 Set up `.i18nizer/` directory for caching and project data
@@ -117,6 +133,9 @@ i18nizer start --framework nextjs --i18n next-intl
 # React with react-i18next
 i18nizer start --framework react --i18n react-i18next
 
+# React with Paraglide JS
+i18nizer start --framework react --i18n paraglide-js
+
 # Custom setup
 i18nizer start --framework custom --i18n custom
 ```
@@ -124,7 +143,7 @@ i18nizer start --framework custom --i18n custom
 **Available options:**
 
 - `--framework`: `nextjs`, `react`, `custom`
-- `--i18n`: `next-intl`, `react-i18next`, `i18next`, `custom`
+- `--i18n`: `next-intl`, `react-i18next`, `i18next`, `paraglide-js`, `custom`
 - `--yes`, `-y`: Skip interactive prompts
 - `--force`, `-f`: Re-initialize existing project
 
@@ -148,6 +167,8 @@ i18nizer translate --all --locales en,es,fr
 i18nizer translate <file> --dry-run
 ```
 
+`translate --dry-run` resolves keys and previews the rewrite flow without calling an AI provider.
+
 **Show generated JSON output:**
 
 ```bash
@@ -170,16 +191,35 @@ This command regenerates the `i18n/messages.generated.ts` file by scanning all J
 
 The aggregator automatically uses valid TypeScript identifiers for imports, converting hyphenated filenames (e.g., `notification-item.json`) to PascalCase identifiers (e.g., `NotificationItem_en`).
 
-### Legacy Command (Still Supported)
+### Extract Source Messages Without AI
 
 ```bash
-i18nizer extract <file-path> --locales en,es,fr --provider openai
+i18nizer extract <file-path> --locales en,es,fr
+```
+
+`extract` is deterministic by default:
+
+- it does **not** require AI translations
+- it writes only the **default/source locale** file
+- it respects the configured output format (`json` or `inlang-message-format`)
+
+Examples:
+
+```bash
+# Standard namespaced JSON
+i18nizer start --framework react --i18n react-i18next
+i18nizer extract src/components/Login.tsx --locales en,es
+
+# Paraglide JS / inlang message format
+i18nizer start --framework react --i18n paraglide-js
+i18nizer extract src/components/Login.tsx --locales en,es
 ```
 
 Flags:
 
-- `--locales` → Languages to generate (default: `en,es`)
-- `--provider` → `openai | gemini | huggingface` (optional)
+- `--locales` → Requested languages; extract writes the default/source locale file
+- `--use-ai-keys` → Use AI for key naming if you explicitly want it
+- `--provider` → `openai | gemini | huggingface` (only relevant with `--use-ai-keys`)
 
 ---
 
@@ -235,6 +275,27 @@ export function Login() {
 
 **Note:** The filename uses lowercase-hyphen format (`login.json`), while the namespace inside uses PascalCase (`Login`).
 
+### Paraglide Output (`messages/en.json`)
+
+```json
+{
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "welcome_back": "Welcome back",
+  "please_sign_in_to_continue": "Please sign in to continue",
+  "sign_in": "Sign in"
+}
+```
+
+With Paraglide config, rewritten code uses `m.key_name()`:
+
+```tsx
+import { m } from "./paraglide/messages.js";
+
+export function Login() {
+  return <button>{m.sign_in()}</button>;
+}
+```
+
 ---
 
 ## 📂 Project Structure
@@ -289,7 +350,7 @@ The `i18nizer.config.yml` file controls all aspects of how i18nizer processes yo
 ```yaml
 # Framework and i18n library settings
 framework: react                    # nextjs | react | custom
-i18nLibrary: react-i18next          # next-intl | react-i18next | i18next | custom
+i18nLibrary: react-i18next          # next-intl | react-i18next | i18next | paraglide-js | custom
 
 # AI provider configuration
 ai:
@@ -303,10 +364,10 @@ paths:
 
 # i18n function configuration
 i18n:
-  function: t                       # Translation function name
+  function: t                       # Translation function name (or m for Paraglide)
   import:
-    source: react-i18next           # Package to import from
-    named: useTranslation           # Named import
+    source: react-i18next           # Package/module to import from
+    named: useTranslation           # Named import (or m for Paraglide)
 
 # Translation file settings
 messages:
@@ -315,7 +376,7 @@ messages:
   locales:                          # List of supported locales
     - en
     - es
-  format: json                      # Output format (currently only json)
+  format: json                      # json | inlang-message-format
 
 # Behavior settings
 behavior:
@@ -523,9 +584,11 @@ These paths serve as defaults and can help organize your project structure. The 
 
 - **Project-level integration** with `i18nizer start` and `i18nizer translate`
 - **Configuration system** with `i18nizer.config.yml`
-- **Framework presets** (Next.js + next-intl, React + react-i18next)
+- **Framework presets** (Next.js + next-intl, React + react-i18next, React + Paraglide JS)
 - **Intelligent caching** to avoid redundant AI translation requests
 - **String deduplication** with deterministic key reuse
+- **AI-free extraction** for source/default locale message files
+- **AI-free dry-run mode**
 - **AI-powered English key generation** for consistent, readable keys regardless of source language
 - **Configurable behavior** (allowed functions, props, member functions)
 - **Dry-run mode** to preview changes
@@ -534,7 +597,7 @@ These paths serve as defaults and can help organize your project structure. The 
 - **Rich text formatting documentation** - patterns for JSX within translations
 - Project-wide or single-file translation
 - Works with **JSX & TSX**
-- Rewrites components automatically (`t("key")`)
+- Rewrites components automatically (`t("key")` or `m.key_name()`)
 - Generates **English camelCase keys** (AI-assisted with deterministic fallback)
 - Supports **any number of locales**
 - Isolated TypeScript parsing (no project tsconfig required)
@@ -564,7 +627,7 @@ These paths serve as defaults and can help organize your project structure. The 
 
 ## 🎨 Advanced i18n Patterns
 
-i18nizer extracts translatable strings and generates standard i18n JSON files. For advanced patterns like pluralization and rich text formatting, you can leverage the built-in features of i18next and next-intl.
+i18nizer extracts translatable strings and generates standard i18n message files. Advanced pluralization and rich text handling depend on the runtime you use; the examples below focus on i18next and next-intl patterns.
 
 ### Pluralization Support
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+
+[install]
+# Supply-chain defense: require packages to be at least 7 days old before
+# installation. Compromised packages (stolen maintainer tokens) are almost
+# always yanked within hours, well before this window elapses.
+minimumReleaseAge = 604800

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -1,21 +1,25 @@
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import ora, { Ora } from "ora";
 
-import { generateTranslations, Provider } from "../core/ai/client.js";
-import { buildPrompt } from "../core/ai/promt.js";
+import { Provider } from "../core/ai/client.js";
 import { extractTexts } from "../core/ast/extract-text.js";
-import { insertUseTranslations } from "../core/ast/insert-user-translations.js";
 import { parseFile } from "../core/ast/parse-file.js";
-import { replaceTempKeysWithT } from "../core/ast/replace-text-with-text.js";
 import { TranslationCache } from "../core/cache/translation-cache.js";
+import {
+  detectFramework,
+  generateConfig,
+  getMessagesDir,
+  isProjectInitialized,
+  loadConfig,
+} from "../core/config/config-manager.js";
 import { Deduplicator } from "../core/deduplication/deduplicator.js";
-import { generateAggregator } from "../core/i18n/generate-aggregator.js";
-import { parseAiJson } from "../core/i18n/parse-ai-json.js";
-import { saveSourceFile } from "../core/i18n/sace-source-file.js";
+import { formatMessageKey } from "../core/i18n/output-format.js";
 import { writeLocaleFiles } from "../core/i18n/write-files.js";
+import { I18nizerConfig } from "../types/config.js";
 
 const VALID_PROVIDERS: Provider[] = ["gemini", "huggingface", "openai"];
 
@@ -31,7 +35,6 @@ export default class Extract extends Command {
   static override flags = {
     locales: Flags.string({
       char: "l",
-      default: "en,es",
       description: "Locales to generate",
     }),
     provider: Flags.string({
@@ -40,8 +43,8 @@ export default class Extract extends Command {
     }),
     "use-ai-keys": Flags.boolean({
       allowNo: true,
-      default: true,
-      description: "Use AI to generate human-readable keys (default: true)",
+      default: false,
+      description: "Use AI to generate human-readable keys (default: false)",
     }),
   };
 
@@ -49,9 +52,24 @@ export default class Extract extends Command {
     const { args, flags } = await this.parse(Extract);
 
     this.log(chalk.cyan("📄 File:"), args.file);
-    this.log(chalk.cyan("🌐 Locales:"), flags.locales);
+    // Load or generate config
+    let config: I18nizerConfig;
+    const cwd = process.cwd();
+    if (isProjectInitialized(cwd)) {
+      config = loadConfig(cwd)!;
+    } else {
+      const framework = detectFramework(cwd);
+      config = generateConfig(framework);
+    }
 
-    let provider: Provider = "huggingface";
+    const requestedLocales = flags.locales
+      ? flags.locales.split(",")
+      : config.messages.locales;
+    const outputLocales = [config.messages.defaultLocale];
+
+    this.log(chalk.cyan("🌐 Locales:"), requestedLocales.join(","));
+
+    let provider: Provider = (config.ai?.provider as Provider) || "huggingface";
     if (flags.provider) {
       const p = flags.provider.toLowerCase();
       if (!VALID_PROVIDERS.includes(p as Provider)) {
@@ -69,7 +87,11 @@ export default class Extract extends Command {
 
     // Parse file
     const sourceFile = parseFile(args.file);
-    const texts = extractTexts(sourceFile);
+    const texts = extractTexts(sourceFile, {
+      allowedFunctions: config.behavior.allowedFunctions,
+      allowedMemberFunctions: config.behavior.allowedMemberFunctions,
+      allowedProps: config.behavior.allowedProps,
+    });
 
     if (texts.length === 0) {
       this.log(chalk.yellow("⚠️  No translatable texts found."));
@@ -79,7 +101,6 @@ export default class Extract extends Command {
     const componentName = path
       .basename(args.file)
       .replace(/\.(tsx|jsx)$/, "");
-    const locales = flags.locales.split(",");
 
     // Count unique strings
     const uniqueTexts = new Set(texts.map((t) => t.text));
@@ -89,12 +110,10 @@ export default class Extract extends Command {
     );
 
     // Initialize cache and deduplicator
-    const cwd = process.cwd();
-    const projectDir = path.join(cwd, ".i18nizer");
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "i18nizer-extract-"));
     const cache = new TranslationCache(projectDir);
     const deduplicator = new Deduplicator(cache, flags["use-ai-keys"], provider);
 
-    // Step 1: Generate keys (batch, cache-first)
     let keySpinner: Ora | undefined;
     if (flags["use-ai-keys"]) {
       keySpinner = ora("🧠 Generating keys (batch)...").start();
@@ -102,133 +121,77 @@ export default class Extract extends Command {
       this.log("🔑 Generating keys (deterministic)...");
     }
 
-    const textList = texts.map((t) => t.text);
-    const deduplicationResults = await deduplicator.deduplicateBatch(
-      textList,
-      componentName,
-      false // Standalone extraction: generate fresh keys without reusing from cache
-    );
-
-    const stats = deduplicator.getStats();
-
-    if (keySpinner) {
-      keySpinner.succeed(
-        `🧠 Generated ${chalk.green(uniqueTexts.size)} keys`
-      );
-    } else {
-      this.log(`✅ Generated ${chalk.green(uniqueTexts.size)} keys (deterministic)`);
-    }
-    
-    this.log(`💾 Cache hits: ${chalk.green(stats.cacheHits)}`);
-    this.log(`🤖 AI requests used: ${chalk.green(stats.aiRequestsUsed)}`);
-
-    // Map results back to texts
-    const mappedTexts = texts.map((t) => {
-      const result = deduplicationResults.get(t.text)!;
-      return {
-        isCached: result.isCached,
-        isPlural: t.isPlural,
-        isRichText: t.isRichText,
-        key: result.key,
-        node: t.node,
-        placeholders: t.placeholders,
-        pluralForms: t.pluralForms,
-        pluralVariable: t.pluralVariable,
-        richTextElements: t.richTextElements,
-        tempKey: t.tempKey,
-        text: t.text,
-      };
-    });
-
-    // Step 2: Generate translations (batch, separate from key generation)
-    const spinner = ora(`💬 Generating translations with ${provider}...`).start();
-
     try {
-      // Build prompt with the keys we already generated
-      const prompt = buildPrompt({
+      const textList = texts.map((t) => t.text);
+      const deduplicationResults = await deduplicator.deduplicateBatch(
+        textList,
         componentName,
-        locales,
-        texts: mappedTexts.map((t) => ({ tempKey: t.tempKey, text: t.text })),
+        config.behavior.detectDuplicates
+      );
+
+      const stats = deduplicator.getStats();
+
+      if (keySpinner) {
+        keySpinner.succeed(
+          `🧠 Generated ${chalk.green(uniqueTexts.size)} keys`
+        );
+      } else {
+        this.log(`✅ Generated ${chalk.green(uniqueTexts.size)} keys (deterministic)`);
+      }
+      
+      this.log(`💾 Cache hits: ${chalk.green(stats.cacheHits)}`);
+      this.log(`🤖 AI requests used: ${chalk.green(stats.aiRequestsUsed)}`);
+
+      const mappedTexts = texts.map((t) => {
+        const result = deduplicationResults.get(t.text)!;
+        return {
+          isPlural: t.isPlural,
+          key: formatMessageKey(result.key, config.messages.format),
+          placeholders: t.placeholders,
+          pluralForms: t.pluralForms,
+          pluralVariable: t.pluralVariable,
+          tempKey: t.tempKey,
+          text: t.text,
+        };
       });
-
-      const raw = await generateTranslations(prompt, provider);
-
-      if (!raw) throw new Error("AI did not return any data");
-
-      const json = parseAiJson(raw);
-      const namespace = componentName;
-      const jsonNamespace =
-        (json[namespace] as Record<string, Record<string, string>>) || {};
 
       const i18nJson: Record<string, Record<string, string>> = {};
 
-      // Use our generated keys, not the AI's keys
       for (const mapped of mappedTexts) {
         i18nJson[mapped.key] = {};
-        
-        // For plural forms, generate ICU format directly
+
         if (mapped.isPlural && mapped.pluralForms) {
-          for (const locale of locales) {
+          for (const locale of outputLocales) {
             const icuFormat = `{${mapped.pluralVariable}, plural, one {${mapped.pluralForms.one}} other {${mapped.pluralForms.other}}}`;
             i18nJson[mapped.key][locale] = icuFormat;
           }
         } else {
-          const translations = jsonNamespace[mapped.tempKey];
-          if (!translations) {
-            throw new Error(`No translations found for tempKey: ${mapped.tempKey}`);
-          }
-
-          for (const locale of locales) {
-            i18nJson[mapped.key][locale] = translations[locale];
+          for (const locale of outputLocales) {
+            i18nJson[mapped.key][locale] = mapped.text;
           }
         }
-
-        // Update cache
-        cache.set({
-          componentName,
-          key: mapped.key,
-          locales: i18nJson[mapped.key],
-          text: mapped.text,
-        });
       }
 
-      writeLocaleFiles(componentName, { [componentName]: i18nJson }, locales);
-
-      spinner.succeed(`✅ Translations generated with ${provider}`);
-
-      this.log(`🔗 Mapped ${chalk.green(mappedTexts.length)} texts to keys`);
-
-      insertUseTranslations(sourceFile, componentName);
-      replaceTempKeysWithT(
-        mappedTexts.map((m) => ({
-          isPlural: m.isPlural,
-          isRichText: m.isRichText,
-          key: m.key,
-          node: m.node,
-          placeholders: m.placeholders,
-          richTextElements: m.richTextElements,
-          tempKey: m.tempKey,
-        }))
+      const messagesDir = getMessagesDir(cwd, config);
+      writeLocaleFiles(
+        componentName,
+        { [componentName]: i18nJson },
+        outputLocales,
+        messagesDir,
+        { format: config.messages.format }
       );
-      saveSourceFile(sourceFile);
-
-      // Save cache
-      cache.save();
-
-      // Generate aggregator (extract uses home directory for standalone mode)
-      const homeDir = os.homedir();
-      const standaloneMessagesDir = path.join(homeDir, ".i18nizer", "messages");
-      generateAggregator(standaloneMessagesDir);
-
-      this.log(chalk.green("✨ Component rewritten with t() calls"));
-      this.log(chalk.green(`🌍 JSON files generated using ${provider}`));
+      this.log(chalk.green("🌍 JSON files generated without AI translations"));
     } catch (error: unknown) {
-      spinner.fail(`❌ Failed to generate translations with ${provider}`);
+      if (keySpinner) {
+        keySpinner.fail("❌ Failed to generate extraction output");
+      }
       if (error instanceof Error) {
         this.error(error.message);
       } else {
         this.error("An unknown error occurred");
       }
+    } finally {
+      fs.rmSync(projectDir, { force: true, recursive: true });
     }
   }
 }

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -17,6 +17,7 @@ import {
   loadConfig,
 } from "../core/config/config-manager.js";
 import { Deduplicator } from "../core/deduplication/deduplicator.js";
+import { resolveFlatMessageKeyCollisions } from "../core/i18n/flat-message-keys.js";
 import { formatMessageKey } from "../core/i18n/output-format.js";
 import { writeLocaleFiles } from "../core/i18n/write-files.js";
 import { I18nizerConfig } from "../types/config.js";
@@ -45,6 +46,11 @@ export default class Extract extends Command {
       allowNo: true,
       default: false,
       description: "Use AI to generate human-readable keys (default: false)",
+    }),
+    "dry-run": Flags.boolean({
+      char: "d",
+      default: false,
+      description: "Preview extracted messages without writing files",
     }),
   };
 
@@ -83,7 +89,14 @@ export default class Extract extends Command {
       provider = p as Provider;
     }
 
-    this.log(chalk.cyan("🤖 Provider:"), provider);
+    this.log(
+      chalk.cyan("🤖 Provider:"),
+      flags["use-ai-keys"] ? provider : "deterministic"
+    );
+
+    if (flags["dry-run"]) {
+      this.log(chalk.yellow("\n🔍 DRY RUN MODE - No files will be modified\n"));
+    }
 
     // Parse file
     const sourceFile = parseFile(args.file);
@@ -150,14 +163,25 @@ export default class Extract extends Command {
           placeholders: t.placeholders,
           pluralForms: t.pluralForms,
           pluralVariable: t.pluralVariable,
+          sequenceNodes: t.sequenceNodes,
           tempKey: t.tempKey,
           text: t.text,
         };
       });
+      const messagesDir = flags["dry-run"] ? null : getMessagesDir(cwd, config);
+      const collisionSafeTexts =
+        config.messages.format === "inlang-message-format" && messagesDir
+          ? resolveFlatMessageKeyCollisions(
+              mappedTexts,
+              componentName,
+              messagesDir,
+              config.messages.defaultLocale
+            )
+          : mappedTexts;
 
       const i18nJson: Record<string, Record<string, string>> = {};
 
-      for (const mapped of mappedTexts) {
+      for (const mapped of collisionSafeTexts) {
         i18nJson[mapped.key] = {};
 
         if (mapped.isPlural && mapped.pluralForms) {
@@ -172,15 +196,18 @@ export default class Extract extends Command {
         }
       }
 
-      const messagesDir = getMessagesDir(cwd, config);
-      writeLocaleFiles(
-        componentName,
-        { [componentName]: i18nJson },
-        outputLocales,
-        messagesDir,
-        { format: config.messages.format }
-      );
-      this.log(chalk.green("🌍 JSON files generated without AI translations"));
+      if (!flags["dry-run"]) {
+        writeLocaleFiles(
+          componentName,
+          { [componentName]: i18nJson },
+          outputLocales,
+          messagesDir!,
+          { format: config.messages.format }
+        );
+        this.log(chalk.green("🌍 JSON files generated without AI translations"));
+      } else {
+        this.log(chalk.green("🌍 Extraction preview generated without writing locale files"));
+      }
     } catch (error: unknown) {
       if (keySpinner) {
         keySpinner.fail("❌ Failed to generate extraction output");

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -31,8 +31,8 @@ export default class Start extends Command {
       options: ["nextjs", "react", "custom"],
     }),
     i18n: Flags.string({
-      description: "i18n library (next-intl, react-i18next, i18next, custom)",
-      options: ["next-intl", "react-i18next", "i18next", "custom"],
+      description: "i18n library (next-intl, react-i18next, i18next, paraglide-js, custom)",
+      options: ["next-intl", "react-i18next", "i18next", "paraglide-js", "custom"],
     }),
     preset: Flags.string({
       char: "p",
@@ -107,6 +107,7 @@ export default class Start extends Command {
               { name: "next-intl", value: "next-intl" },
               { name: "react-i18next", value: "react-i18next" },
               { name: "i18next", value: "i18next" },
+              { name: "paraglide-js", value: "paraglide-js" },
               { name: "Custom / None", value: "custom" },
             ],
             default: detectedI18n ?? "custom",

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -1,5 +1,7 @@
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import ora from "ora";
 
@@ -20,6 +22,7 @@ import {
 } from "../core/config/config-manager.js";
 import { Deduplicator } from "../core/deduplication/deduplicator.js";
 import { generateAggregator } from "../core/i18n/generate-aggregator.js";
+import { formatMessageKey } from "../core/i18n/output-format.js";
 import { parseAiJson } from "../core/i18n/parse-ai-json.js";
 import { saveSourceFile } from "../core/i18n/sace-source-file.js";
 import { writeLocaleFiles } from "../core/i18n/write-files.js";
@@ -142,11 +145,14 @@ export default class Translate extends Command {
     }
 
     // Initialize cache and deduplicator
-    const projectDir = getProjectDir(cwd);
+    const tempProjectDir = flags["dry-run"]
+      ? fs.mkdtempSync(path.join(os.tmpdir(), "i18nizer-dry-run-"))
+      : undefined;
+    const projectDir = tempProjectDir ?? getProjectDir(cwd);
     const cache = new TranslationCache(projectDir);
     const deduplicator = new Deduplicator(
       cache,
-      config.behavior.useAiForKeys,
+      !flags["dry-run"] && config.behavior.useAiForKeys,
       provider
     );
 
@@ -154,123 +160,124 @@ export default class Translate extends Command {
     let totalReused = 0;
     let totalCached = 0;
 
-    // Process each file sequentially
-    for (const filePath of filesToProcess) {
-      const componentName = path.basename(filePath).replace(/\.(tsx|jsx)$/, "");
-      const spinner = ora(`Processing ${componentName}...`).start();
+    try {
+      // Process each file sequentially
+      for (const filePath of filesToProcess) {
+        const componentName = path.basename(filePath).replace(/\.(tsx|jsx)$/, "");
+        const spinner = ora(`Processing ${componentName}...`).start();
 
-      try {
-        // Parse and extract
-        const sourceFile = parseFile(filePath);
-        const texts = extractTexts(sourceFile, {
-          allowedFunctions: config.behavior.allowedFunctions,
-          allowedMemberFunctions: config.behavior.allowedMemberFunctions,
-          allowedProps: config.behavior.allowedProps,
-        });
+        try {
+          // Parse and extract
+          const sourceFile = parseFile(filePath);
+          const texts = extractTexts(sourceFile, {
+            allowedFunctions: config.behavior.allowedFunctions,
+            allowedMemberFunctions: config.behavior.allowedMemberFunctions,
+            allowedProps: config.behavior.allowedProps,
+          });
 
-        if (texts.length === 0) {
-          spinner.info(`⏭️  ${componentName}: No translatable texts found`);
-          continue;
-        }
+          if (texts.length === 0) {
+            spinner.info(`⏭️  ${componentName}: No translatable texts found`);
+            continue;
+          }
 
-        totalExtracted += texts.length;
+          totalExtracted += texts.length;
 
-        // Deduplicate and assign keys using batch processing
-        const textList = texts.map((t) => t.text);
-        
-        // eslint-disable-next-line no-await-in-loop
-        const deduplicationResults = await deduplicator.deduplicateBatch(
-          textList,
-          componentName,
-          config.behavior.detectDuplicates
-        );
-
-        // Map results back to texts
-        const mappedTexts = texts.map((t) => {
-          const result = deduplicationResults.get(t.text)!;
+          // Deduplicate and assign keys using batch processing
+          const textList = texts.map((t) => t.text);
           
-          if (result.isReused) totalReused++;
-          if (result.isCached) totalCached++;
+          // eslint-disable-next-line no-await-in-loop
+          const deduplicationResults = await deduplicator.deduplicateBatch(
+            textList,
+            componentName,
+            config.behavior.detectDuplicates
+          );
 
-          return {
-            isCached: result.isCached,
-            isPlural: t.isPlural,
-            isRichText: t.isRichText,
-            key: result.key,
-            node: t.node,
-            placeholders: t.placeholders,
-            pluralForms: t.pluralForms,
-            pluralVariable: t.pluralVariable,
-            richTextElements: t.richTextElements,
-            tempKey: t.tempKey,
-            text: t.text,
-          };
-        });
+          // Map results back to texts
+          const mappedTexts = texts.map((t) => {
+            const result = deduplicationResults.get(t.text)!;
+            const formattedKey = formatMessageKey(result.key, config.messages.format);
 
-        // Build translations JSON
-        const i18nJson: Record<string, Record<string, string>> = {};
+            if (result.isReused) totalReused++;
+            if (result.isCached) totalCached++;
 
-        for (const mapped of mappedTexts) {
-          i18nJson[mapped.key] = {};
+            return {
+              isCached: result.isCached,
+              isPlural: t.isPlural,
+              isRichText: t.isRichText,
+              key: formattedKey,
+              node: t.node,
+              placeholders: t.placeholders,
+              pluralForms: t.pluralForms,
+              pluralVariable: t.pluralVariable,
+              richTextElements: t.richTextElements,
+              tempKey: t.tempKey,
+              text: t.text,
+            };
+          });
 
-          if (mapped.isCached) {
-            // Use cached translations
-            const cached = cache.get(mapped.text)!;
-            for (const locale of locales) {
-              i18nJson[mapped.key][locale] =
-                cached.locales[locale] ?? mapped.text;
-            }
-          } else {
-            // For plural forms, generate ICU format
-            if (mapped.isPlural && mapped.pluralForms) {
+          // Build translations JSON
+          const i18nJson: Record<string, Record<string, string>> = {};
+
+          for (const mapped of mappedTexts) {
+            i18nJson[mapped.key] = {};
+
+            if (mapped.isCached) {
+              const cached = cache.get(mapped.text)!;
               for (const locale of locales) {
-                // Generate ICU plural format string
+                i18nJson[mapped.key][locale] = cached.locales[locale] ?? mapped.text;
+              }
+            } else if (mapped.isPlural && mapped.pluralForms) {
+              for (const locale of locales) {
                 const icuFormat = `{${mapped.pluralVariable}, plural, one {${mapped.pluralForms.one}} other {${mapped.pluralForms.other}}}`;
                 i18nJson[mapped.key][locale] = icuFormat;
               }
-            } else {
-              // Will need AI translation
+            } else if (flags["dry-run"]) {
               for (const locale of locales) {
-                i18nJson[mapped.key][locale] = ""; // Placeholder
+                i18nJson[mapped.key][locale] = mapped.text;
+              }
+            } else {
+              for (const locale of locales) {
+                i18nJson[mapped.key][locale] = "";
               }
             }
           }
-        }
 
-        // Get AI translations for non-cached texts
-        const textsNeedingTranslation = mappedTexts.filter((t) => !t.isCached);
+          const textsNeedingTranslation = flags["dry-run"]
+            ? []
+            : mappedTexts.filter((t) => !t.isCached && !t.isPlural);
 
-        if (textsNeedingTranslation.length > 0) {
-          spinner.text = `${componentName}: Generating translations with ${provider}...`;
+          if (textsNeedingTranslation.length > 0) {
+            spinner.text = `${componentName}: Generating translations with ${provider}...`;
 
-          const prompt = buildPrompt({
-            componentName,
-            locales,
-            texts: textsNeedingTranslation.map((t) => ({
-              tempKey: t.tempKey,
-              text: t.text,
-            })),
-          });
+            const prompt = buildPrompt({
+              componentName,
+              locales,
+              texts: textsNeedingTranslation.map((t) => ({
+                tempKey: t.tempKey,
+                text: t.text,
+              })),
+            });
 
-          // eslint-disable-next-line no-await-in-loop
-          const raw = await generateTranslations(prompt, provider, aiModel);
-          if (!raw) throw new Error("AI did not return any data");
+            // eslint-disable-next-line no-await-in-loop
+            const raw = await generateTranslations(prompt, provider, aiModel);
+            if (!raw) throw new Error("AI did not return any data");
 
-          const aiJson = parseAiJson(raw);
-          const namespace = aiJson[componentName] as Record<
-            string,
-            Record<string, string>
-          >;
+            const aiJson = parseAiJson(raw);
+            const namespace = aiJson[componentName] as Record<
+              string,
+              Record<string, string>
+            >;
 
-          // Merge AI translations
-          for (const mapped of textsNeedingTranslation) {
-            const aiTranslations = namespace[mapped.tempKey];
-            if (aiTranslations) {
+            for (const mapped of textsNeedingTranslation) {
+              const aiTranslations = namespace[mapped.tempKey];
+              if (!aiTranslations) {
+                continue;
+              }
+
               for (const locale of locales) {
                 i18nJson[mapped.key][locale] = aiTranslations[locale] ?? mapped.text;
               }
 
-              // Update cache
               cache.set({
                 componentName,
                 key: mapped.key,
@@ -279,70 +286,72 @@ export default class Translate extends Command {
               });
             }
           }
-        }
 
-        // Show JSON if requested
-        if (flags["show-json"]) {
-          this.log("\n" + chalk.cyan(`${componentName} JSON:`));
-          this.log(JSON.stringify({ [componentName]: i18nJson }, null, 2));
-          this.log("");
-        }
+          if (flags["show-json"]) {
+            this.log("\n" + chalk.cyan(`${componentName} JSON:`));
+            this.log(JSON.stringify({ [componentName]: i18nJson }, null, 2));
+            this.log("");
+          }
 
-        // Write files (unless dry-run)
-        if (!flags["dry-run"]) {
-          // Write locale files
-          if (isInitialized) {
+          if (!flags["dry-run"]) {
             const messagesDir = getMessagesDir(cwd, config);
-            writeLocaleFiles(componentName, { [componentName]: i18nJson }, locales, messagesDir);
-          } else {
-            // Standalone mode: use home directory
-            writeLocaleFiles(componentName, { [componentName]: i18nJson }, locales);
-          }
+            writeLocaleFiles(
+              componentName,
+              { [componentName]: i18nJson },
+              locales,
+              messagesDir,
+              { format: config.messages.format }
+            );
 
-          // Rewrite component
-          // Only inject t function if autoInjectT is enabled
-          if (config.behavior.autoInjectT) {
-            insertUseTranslations(sourceFile, componentName);
-          }
-          
-          replaceTempKeysWithT(
-            mappedTexts.map((m) => ({
-              isPlural: m.isPlural,
-              isRichText: m.isRichText,
-              key: m.key,
-              node: m.node,
-              placeholders: m.placeholders,
-              richTextElements: m.richTextElements,
-              tempKey: m.tempKey,
-            })),
-            {
-              allowedFunctions: config.behavior.allowedFunctions,
-              allowedMemberFunctions: config.behavior.allowedMemberFunctions,
-              allowedProps: config.behavior.allowedProps,
+            if (config.behavior.autoInjectT) {
+              insertUseTranslations(sourceFile, componentName, {
+                i18nLibrary: config.i18nLibrary,
+                import: config.i18n.import,
+              });
             }
-          );
-          saveSourceFile(sourceFile);
-        }
+            
+            replaceTempKeysWithT(
+              mappedTexts.map((m) => ({
+                isPlural: m.isPlural,
+                isRichText: m.isRichText,
+                key: m.key,
+                node: m.node,
+                placeholders: m.placeholders,
+                richTextElements: m.richTextElements,
+                tempKey: m.tempKey,
+              })),
+              {
+                allowedFunctions: config.behavior.allowedFunctions,
+                allowedMemberFunctions: config.behavior.allowedMemberFunctions,
+                allowedProps: config.behavior.allowedProps,
+                i18nLibrary: config.i18nLibrary,
+              }
+            );
+            saveSourceFile(sourceFile);
+          }
 
-        spinner.succeed(
-          `✅ ${componentName}: ${texts.length} strings (${totalReused} reused, ${totalCached} cached)`
-        );
-      } catch (error: unknown) {
-        spinner.fail(`❌ ${componentName}: Failed`);
-        if (error instanceof Error) {
-          this.error(error.message);
+          spinner.succeed(
+            `✅ ${componentName}: ${texts.length} strings (${totalReused} reused, ${totalCached} cached)`
+          );
+        } catch (error: unknown) {
+          spinner.fail(`❌ ${componentName}: Failed`);
+          if (error instanceof Error) {
+            this.error(error.message);
+          }
         }
       }
-    }
 
-    // Save cache
-    if (!flags["dry-run"]) {
-      cache.save();
+      if (!flags["dry-run"]) {
+        cache.save();
 
-      // Generate aggregator if project is initialized
-      if (isInitialized) {
-        const messagesDir = getMessagesDir(cwd, config);
-        generateAggregator(messagesDir);
+        if (isInitialized && config.messages.format === "json") {
+          const messagesDir = getMessagesDir(cwd, config);
+          generateAggregator(messagesDir);
+        }
+      }
+    } finally {
+      if (tempProjectDir) {
+        fs.rmSync(tempProjectDir, { force: true, recursive: true });
       }
     }
 

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -22,6 +22,7 @@ import {
 } from "../core/config/config-manager.js";
 import { Deduplicator } from "../core/deduplication/deduplicator.js";
 import { generateAggregator } from "../core/i18n/generate-aggregator.js";
+import { resolveFlatMessageKeyCollisions } from "../core/i18n/flat-message-keys.js";
 import { formatMessageKey } from "../core/i18n/output-format.js";
 import { parseAiJson } from "../core/i18n/parse-ai-json.js";
 import { saveSourceFile } from "../core/i18n/sace-source-file.js";
@@ -138,7 +139,10 @@ export default class Translate extends Command {
       chalk.bold(filesToProcess.length)
     );
     this.log(chalk.cyan("🌐 Locales:"), locales.join(", "));
-    this.log(chalk.cyan("🤖 Provider:"), provider);
+    this.log(
+      chalk.cyan("🤖 Provider:"),
+      flags["dry-run"] ? "deterministic" : provider
+    );
 
     if (flags["dry-run"]) {
       this.log(chalk.yellow("\n🔍 DRY RUN MODE - No files will be modified\n"));
@@ -210,15 +214,29 @@ export default class Translate extends Command {
               pluralForms: t.pluralForms,
               pluralVariable: t.pluralVariable,
               richTextElements: t.richTextElements,
+              sequenceNodes: t.sequenceNodes,
               tempKey: t.tempKey,
               text: t.text,
             };
           });
+          const messagesDir = flags["dry-run"] ? null : getMessagesDir(cwd, config);
+          const collisionLocale = locales.includes(config.messages.defaultLocale)
+            ? config.messages.defaultLocale
+            : locales[0];
+          const collisionSafeTexts =
+            config.messages.format === "inlang-message-format" && messagesDir
+              ? resolveFlatMessageKeyCollisions(
+                  mappedTexts,
+                  componentName,
+                  messagesDir,
+                  collisionLocale
+                )
+              : mappedTexts;
 
           // Build translations JSON
           const i18nJson: Record<string, Record<string, string>> = {};
 
-          for (const mapped of mappedTexts) {
+          for (const mapped of collisionSafeTexts) {
             i18nJson[mapped.key] = {};
 
             if (mapped.isCached) {
@@ -244,7 +262,7 @@ export default class Translate extends Command {
 
           const textsNeedingTranslation = flags["dry-run"]
             ? []
-            : mappedTexts.filter((t) => !t.isCached && !t.isPlural);
+            : collisionSafeTexts.filter((t) => !t.isCached && !t.isPlural);
 
           if (textsNeedingTranslation.length > 0) {
             spinner.text = `${componentName}: Generating translations with ${provider}...`;
@@ -294,12 +312,11 @@ export default class Translate extends Command {
           }
 
           if (!flags["dry-run"]) {
-            const messagesDir = getMessagesDir(cwd, config);
             writeLocaleFiles(
               componentName,
               { [componentName]: i18nJson },
               locales,
-              messagesDir,
+              messagesDir!,
               { format: config.messages.format }
             );
 
@@ -311,7 +328,8 @@ export default class Translate extends Command {
             }
             
             replaceTempKeysWithT(
-              mappedTexts.map((m) => ({
+              collisionSafeTexts.map((m) => ({
+                sequenceNodes: m.sequenceNodes,
                 isPlural: m.isPlural,
                 isRichText: m.isRichText,
                 key: m.key,

--- a/src/core/ast/extract-text.ts
+++ b/src/core/ast/extract-text.ts
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { Node } from "ts-morph";
+import { JsxElement, JsxFragment, Node } from "ts-morph";
 
 import { isTranslatableString } from "./is-translatable.js";
 
@@ -23,6 +23,7 @@ const defaultAllowedProps = new Set([
 export interface ExtractedText {
     node: Node;
     placeholders: string[];
+    sequenceNodes?: Node[];
     tempKey: string;
     text: string;
     isPlural?: boolean;
@@ -45,6 +46,20 @@ export interface ExtractOptions {
 }
 
 // --- Helpers ---
+
+function isJsxContainer(node: Node): node is JsxElement | JsxFragment {
+    return Node.isJsxElement(node) || Node.isJsxFragment(node);
+}
+
+function normalizeFormattedJsxText(text: string): string {
+    if (!/[\n\r\t]/.test(text)) {
+        return text;
+    }
+
+    return text
+        .replaceAll(/\s*\n\s*/g, " ")
+        .replaceAll(/[ \t]{2,}/g, " ");
+}
 
 function processTemplateLiteral(node: Node): null | { placeholders: string[]; text: string } {
     if (Node.isNoSubstitutionTemplateLiteral(node)) {
@@ -92,7 +107,7 @@ function extractRichTextContent(jsxElement: Node): null | {
 
     for (const child of children) {
         if (Node.isJsxText(child)) {
-            richText += child.getText();
+            richText += normalizeFormattedJsxText(child.getFullText());
         } else if (Node.isJsxElement(child)) {
             const opening = child.getOpeningElement();
             const tagName = opening.getTagNameNode().getText();
@@ -101,7 +116,7 @@ function extractRichTextContent(jsxElement: Node): null | {
             // Get inner text of the element
             const innerText = child.getJsxChildren()
                 .filter(c => Node.isJsxText(c))
-                .map(c => c.getText())
+                .map(c => normalizeFormattedJsxText(c.getFullText()))
                 .join('');
 
             // Add to rich text with placeholder
@@ -129,12 +144,8 @@ function detectRichTextPattern(jsxElement: Node): null | {
     elements: Array<{ tag: string; placeholder: string }>;
     hasText: boolean;
 } {
-    if (!Node.isJsxElement(jsxElement) && !Node.isJsxSelfClosingElement(jsxElement)) {
+    if (!Node.isJsxElement(jsxElement)) {
         return null;
-    }
-
-    if (Node.isJsxSelfClosingElement(jsxElement)) {
-        return null; // Self-closing elements don't have rich text
     }
 
     const children = jsxElement.getJsxChildren();
@@ -144,18 +155,15 @@ function detectRichTextPattern(jsxElement: Node): null | {
 
     for (const child of children) {
         if (Node.isJsxText(child)) {
-            const text = child.getText().trim();
+            const text = normalizeFormattedJsxText(child.getFullText()).trim();
             if (text.length > 0) {
                 hasText = true;
             }
-        } else if (Node.isJsxElement(child) || Node.isJsxSelfClosingElement(child)) {
+        } else if (Node.isJsxElement(child)) {
             hasJsxElement = true;
 
             // Get tag name
-            const opening = Node.isJsxElement(child)
-                ? child.getOpeningElement()
-                : child;
-            const tagName = opening.getTagNameNode().getText();
+            const tagName = child.getOpeningElement().getTagNameNode().getText();
 
             // Generate placeholder name based on tag
             const placeholder = tagName.toLowerCase();
@@ -240,6 +248,176 @@ function getFullCallName(node: Node): null | string {
     return null;
 }
 
+function isVariableUsedInJsx(variableDeclaration: Node): boolean {
+    if (!Node.isVariableDeclaration(variableDeclaration)) {
+        return false;
+    }
+
+    const nameNode = variableDeclaration.getNameNode();
+    const variableName = nameNode.getText();
+
+    return variableDeclaration
+        .getSourceFile()
+        .getDescendants()
+        .some((descendant) => {
+            if (!Node.isIdentifier(descendant) || descendant.getText() !== variableName) {
+                return false;
+            }
+
+            if (descendant.getStart() === nameNode.getStart()) {
+                return false;
+            }
+
+            return Boolean(descendant.getFirstAncestor((ancestor) => Node.isJsxExpression(ancestor)));
+        });
+}
+
+function addExtractedText(
+    node: Node,
+    text: string,
+    results: ExtractedText[],
+    seenNodes: Set<Node>,
+    placeholders: string[] = [],
+    sequenceNodes?: Node[]
+) {
+    if (!isTranslatableString(node, text)) {
+        return;
+    }
+
+    const tempKey = `i$fdw_${tempIdCounter++}`;
+    results.push({ node, placeholders, sequenceNodes, tempKey, text });
+    seenNodes.add(node);
+
+    if (sequenceNodes) {
+        for (const sequenceNode of sequenceNodes) {
+            seenNodes.add(sequenceNode);
+        }
+    }
+}
+
+function extractStringsFromVariableInitializer(
+    initializer: Node,
+    results: ExtractedText[],
+    seenNodes: Set<Node>
+) {
+    if (Node.isArrayLiteralExpression(initializer)) {
+        for (const element of initializer.getElements()) {
+            extractStringsFromExpression(element, results, seenNodes);
+        }
+        return;
+    }
+
+    extractStringsFromExpression(initializer, results, seenNodes);
+}
+
+function getSequenceExpressionFragment(expr: Node): null | { placeholders: string[]; text: string } {
+    if (Node.isIdentifier(expr)) {
+        return {
+            placeholders: [expr.getText()],
+            text: `{${expr.getText()}}`,
+        };
+    }
+
+    if (Node.isNumericLiteral(expr)) {
+        return {
+            placeholders: [],
+            text: expr.getText(),
+        };
+    }
+
+    if (Node.isStringLiteral(expr)) {
+        return {
+            placeholders: [],
+            text: expr.getLiteralText(),
+        };
+    }
+
+    if (Node.isNoSubstitutionTemplateLiteral(expr) || Node.isTemplateExpression(expr)) {
+        return processTemplateLiteral(expr);
+    }
+
+    if (Node.isParenthesizedExpression(expr)) {
+        return getSequenceExpressionFragment(expr.getExpression());
+    }
+
+    return null;
+}
+
+function extractJsxSequence(jsxNode: Node): null | {
+    node: Node;
+    placeholders: string[];
+    sequenceNodes: Node[];
+    text: string;
+} {
+    if (!isJsxContainer(jsxNode)) {
+        return null;
+    }
+
+    const children = jsxNode.getJsxChildren();
+    const sequenceNodes: Node[] = [];
+    const placeholders: string[] = [];
+    let hasTextOrBreak = false;
+    let meaningfulNodeCount = 0;
+    let text = "";
+
+    for (const child of children) {
+        if (Node.isJsxText(child)) {
+            if (child.getFullText().trim().length === 0) {
+                continue;
+            }
+
+            sequenceNodes.push(child);
+            meaningfulNodeCount++;
+            hasTextOrBreak = true;
+            text += normalizeFormattedJsxText(child.getFullText());
+            continue;
+        }
+
+        if (Node.isJsxSelfClosingElement(child)) {
+            if (child.getTagNameNode().getText() !== "br") {
+                return null;
+            }
+
+            sequenceNodes.push(child);
+            meaningfulNodeCount++;
+            hasTextOrBreak = true;
+            text += "\n";
+            continue;
+        }
+
+        if (Node.isJsxExpression(child)) {
+            const expr = child.getExpression();
+            if (!expr) {
+                continue;
+            }
+
+            const fragment = getSequenceExpressionFragment(expr);
+            if (!fragment) {
+                return null;
+            }
+
+            sequenceNodes.push(child);
+            meaningfulNodeCount++;
+            text += fragment.text;
+            placeholders.push(...fragment.placeholders);
+            continue;
+        }
+
+        return null;
+    }
+
+    if (!hasTextOrBreak || meaningfulNodeCount <= 1 || sequenceNodes.length === 0) {
+        return null;
+    }
+
+    return {
+        node: sequenceNodes[0],
+        placeholders,
+        sequenceNodes,
+        text,
+    };
+}
+
 /**
  * Recursively extract string literals from complex expressions
  * like ternary operators, logical operators, etc.
@@ -250,11 +428,7 @@ function extractStringsFromExpression(expr: Node, results: ExtractedText[], seen
     // String literal
     if (Node.isStringLiteral(expr)) {
         const text = expr.getLiteralText();
-        if (isTranslatableString(expr, text)) {
-            const tempKey = `i$fdw_${tempIdCounter++}`;
-            results.push({ node: expr, placeholders: [], tempKey, text });
-            seenNodes.add(expr);
-        }
+        addExtractedText(expr, text, results, seenNodes);
 
         return;
     }
@@ -262,10 +436,8 @@ function extractStringsFromExpression(expr: Node, results: ExtractedText[], seen
     // Template literal
     if (Node.isTemplateExpression(expr) || Node.isNoSubstitutionTemplateLiteral(expr)) {
         const processed = processTemplateLiteral(expr);
-        if (processed && isTranslatableString(expr, processed.text)) {
-            const tempKey = `i$fdw_${tempIdCounter++}`;
-            results.push({ node: expr, placeholders: processed.placeholders, tempKey, text: processed.text });
-            seenNodes.add(expr);
+        if (processed) {
+            addExtractedText(expr, processed.text, results, seenNodes, processed.placeholders);
         }
 
         return;
@@ -337,6 +509,13 @@ export function extractTexts(sourceFile: Node, options: ExtractOptions = {}): Ex
     sourceFile.forEachDescendant((node: Node) => {
         if (seenNodes.has(node)) return;
 
+        if (Node.isVariableDeclaration(node) && isVariableUsedInJsx(node)) {
+            const initializer = node.getInitializer();
+            if (initializer) {
+                extractStringsFromVariableInitializer(initializer, results, seenNodes);
+            }
+        }
+
         // Check for rich text pattern in JSX elements
         if (Node.isJsxElement(node)) {
             const richContent = extractRichTextContent(node);
@@ -358,6 +537,21 @@ export function extractTexts(sourceFile: Node, options: ExtractOptions = {}): Ex
             }
         }
 
+        if (isJsxContainer(node)) {
+            const sequence = extractJsxSequence(node);
+            if (sequence) {
+                addExtractedText(
+                    sequence.node,
+                    sequence.text,
+                    results,
+                    seenNodes,
+                    sequence.placeholders,
+                    sequence.sequenceNodes
+                );
+                return;
+            }
+        }
+
         let text: null | string = null;
         let placeholders: string[] = [];
 
@@ -366,15 +560,16 @@ export function extractTexts(sourceFile: Node, options: ExtractOptions = {}): Ex
             const parent = node.getParent();
 
             // Solo permitir texto visible dentro de un elemento JSX
-            if (!Node.isJsxElement(parent)) return;
+            if (!isJsxContainer(parent)) return;
 
-            text = node.getText().trim();
-            if (!text) return;
+            const rawText = node.getFullText();
+            if (rawText.trim().length === 0) return;
+            text = /[\n\r\t]/.test(rawText)
+                ? normalizeFormattedJsxText(rawText).trim()
+                : rawText;
             if (!isTranslatableString(node, text)) return;
 
-            const tempKey = `i$fdw_${tempIdCounter++}`;
-            results.push({ node, placeholders, tempKey, text });
-            seenNodes.add(node);
+            addExtractedText(node, text, results, seenNodes, placeholders);
             return;
         }
 
@@ -394,7 +589,7 @@ export function extractTexts(sourceFile: Node, options: ExtractOptions = {}): Ex
                 }
             }
 
-            if (Node.isJsxElement(parent)) {
+            if (isJsxContainer(parent)) {
                 shouldExtract = true;
             }
 
@@ -445,9 +640,7 @@ export function extractTexts(sourceFile: Node, options: ExtractOptions = {}): Ex
         }
 
         if (shouldExtract) {
-            const tempKey = `i$fdw_${tempIdCounter++}`;
-            results.push({ node, placeholders, tempKey, text });
-            seenNodes.add(node);
+            addExtractedText(node, text, results, seenNodes, placeholders);
         }
     });
 

--- a/src/core/ast/insert-user-translations.ts
+++ b/src/core/ast/insert-user-translations.ts
@@ -1,6 +1,50 @@
 import { Block, SourceFile, SyntaxKind, VariableDeclaration, VariableDeclarationKind } from "ts-morph";
 
-export function insertUseTranslations(sourceFile: SourceFile, namespace: string) {
+export interface InsertTranslationsOptions {
+    i18nLibrary?: string;
+    import?: {
+        named: string;
+        source: string;
+    };
+}
+
+function ensureNamedImport(
+    sourceFile: SourceFile,
+    namedImport: string,
+    moduleSpecifier: string
+) {
+    const existingImport = sourceFile.getImportDeclaration(
+        (declaration) => declaration.getModuleSpecifierValue() === moduleSpecifier
+    );
+
+    if (existingImport) {
+        const hasNamedImport = existingImport
+            .getNamedImports()
+            .some((named) => named.getName() === namedImport);
+
+        if (!hasNamedImport) {
+            existingImport.addNamedImport(namedImport);
+        }
+
+        return;
+    }
+
+    sourceFile.insertImportDeclaration(0, {
+        moduleSpecifier,
+        namedImports: [namedImport],
+    });
+}
+
+export function insertUseTranslations(
+    sourceFile: SourceFile,
+    namespace: string,
+    options: InsertTranslationsOptions = {}
+) {
+    if (options.i18nLibrary === "paraglide-js" && options.import) {
+        ensureNamedImport(sourceFile, options.import.named, options.import.source);
+        return;
+    }
+
     const defaultExport = sourceFile.getDefaultExportSymbol();
     if (!defaultExport) return;
 

--- a/src/core/ast/replace-text-with-text.ts
+++ b/src/core/ast/replace-text-with-text.ts
@@ -18,6 +18,7 @@ export interface ReplaceOptions {
     allowedFunctions?: string[];
     allowedMemberFunctions?: string[];
     allowedProps?: string[];
+    i18nLibrary?: string;
 }
 
 // Default allowed JSX props to replace text
@@ -55,10 +56,19 @@ function getFullCallName(node: Node): null | string {
     return null;
 }
 
+function buildParaglideAccessor(key: string): string {
+    if (/^[$A-Z_a-z][$\w]*$/.test(key)) {
+        return `m.${key}`;
+    }
+
+    return `m[${JSON.stringify(key)}]`;
+}
+
 export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptions = {}) {
     const allowedProps = new Set(options.allowedProps ?? [...defaultAllowedProps]);
     const allowedFunctions = new Set(options.allowedFunctions ?? [...defaultAllowedFunctions]);
     const allowedMemberFunctions = new Set(options.allowedMemberFunctions ?? [...defaultAllowedMemberFunctions]);
+    const isParaglide = options.i18nLibrary === "paraglide-js";
     
     for (const { key, node, placeholders = [], isPlural = false, isRichText = false, richTextElements = [] } of mapped) {
         // For rich text patterns, generate t.rich() call
@@ -68,7 +78,9 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
                 return `${elem.placeholder}: (chunks) => <${elem.tag}>{chunks}</${elem.tag}>`;
             }).join(', ');
             
-            const richCall = `t.rich("${key}", { ${formatters} })`;
+            const richCall = isParaglide
+                ? `${buildParaglideAccessor(key)}()`
+                : `t.rich("${key}", { ${formatters} })`;
             
             // Replace the entire JSX element with {t.rich(...)}
             node.replaceWithText(`{${richCall}}`);
@@ -80,7 +92,9 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
             ? `{ ${placeholders.map(p => `${p}: ${p}`).join(", ")} }`
             : "";
 
-        const tCall = `t("${key}"${placeholdersText ? `, ${placeholdersText}` : ""})`;
+        const tCall = isParaglide
+            ? `${buildParaglideAccessor(key)}(${placeholdersText})`
+            : `t("${key}"${placeholdersText ? `, ${placeholdersText}` : ""})`;
 
         // For plural patterns (ternary expressions), replace the entire ternary
         if (isPlural && Node.isConditionalExpression(node)) {

--- a/src/core/ast/replace-text-with-text.ts
+++ b/src/core/ast/replace-text-with-text.ts
@@ -5,6 +5,7 @@ interface MappedText {
     key: string;
     node: Node;
     placeholders?: string[];
+    sequenceNodes?: Node[];
     tempKey: string;
     isPlural?: boolean;
     isRichText?: boolean;
@@ -70,7 +71,7 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
     const allowedMemberFunctions = new Set(options.allowedMemberFunctions ?? [...defaultAllowedMemberFunctions]);
     const isParaglide = options.i18nLibrary === "paraglide-js";
     
-    for (const { key, node, placeholders = [], isPlural = false, isRichText = false, richTextElements = [] } of mapped) {
+    for (const { key, node, placeholders = [], sequenceNodes = [], isPlural = false, isRichText = false, richTextElements = [] } of mapped) {
         // For rich text patterns, generate t.rich() call
         if (isRichText && Node.isJsxElement(node)) {
             // Build formatter functions for each element
@@ -95,6 +96,15 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
         const tCall = isParaglide
             ? `${buildParaglideAccessor(key)}(${placeholdersText})`
             : `t("${key}"${placeholdersText ? `, ${placeholdersText}` : ""})`;
+
+        if (sequenceNodes.length > 0) {
+            const [firstNode, ...restNodes] = sequenceNodes;
+            firstNode.replaceWithText(`{${tCall}}`);
+            for (const sequenceNode of restNodes) {
+                sequenceNode.replaceWithText("");
+            }
+            continue;
+        }
 
         // For plural patterns (ternary expressions), replace the entire ternary
         if (isPlural && Node.isConditionalExpression(node)) {
@@ -146,6 +156,9 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
                     node.replaceWithText(tCall);
                 }
             }
+            else if (Node.isVariableDeclaration(parent) || Node.isArrayLiteralExpression(parent)) {
+                node.replaceWithText(tCall);
+            }
         }
         // Replace template literals
         else if (Node.isNoSubstitutionTemplateLiteral(node) || Node.isTemplateExpression(node)) {
@@ -169,6 +182,9 @@ export function replaceTempKeysWithT(mapped: MappedText[], options: ReplaceOptio
                 if (fnName && (allowedFunctions.has(fnName) || allowedMemberFunctions.has(fnName))) {
                     node.replaceWithText(tCall);
                 }
+            }
+            else if (Node.isVariableDeclaration(parent) || Node.isArrayLiteralExpression(parent)) {
+                node.replaceWithText(tCall);
             }
         }
     }

--- a/src/core/config/config-manager.ts
+++ b/src/core/config/config-manager.ts
@@ -47,6 +47,10 @@ export function detectI18nLibrary(cwd: string): I18nLibrary | null {
       const deps = { ...packageJson.dependencies, ...packageJson.devDependencies };
       
       // Check in order of specificity
+      if (deps["@inlang/paraglide-js"]) {
+        return "paraglide-js";
+      }
+
       if (deps["next-intl"]) {
         return "next-intl";
       }
@@ -153,11 +157,7 @@ export function generateConfig(framework: Framework, i18nLibrary?: I18nLibrary):
   // Framework settings take precedence for non-i18n specific fields
   if (i18nLibrary) {
     const i18nConfig = I18N_LIBRARY_CONFIGS[i18nLibrary];
-    return {
-      ...baseConfig,
-      i18n: i18nConfig.i18n ?? baseConfig.i18n,
-      i18nLibrary: i18nConfig.i18nLibrary,
-    };
+    return mergeConfig(baseConfig, i18nConfig);
   }
   
   return baseConfig;

--- a/src/core/i18n/flat-message-keys.ts
+++ b/src/core/i18n/flat-message-keys.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { componentNameToFilename } from "./filename-utils.js";
+import { formatMessageKey } from "./output-format.js";
+
+function readFlatMessageFile(filePath: string): Record<string, string> {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  try {
+    const content = JSON.parse(fs.readFileSync(filePath, "utf8")) as Record<string, string>;
+    delete content.$schema;
+    return content;
+  } catch {
+    return {};
+  }
+}
+
+function reserveCollisionSafeKey(
+  baseKey: string,
+  namespace: string,
+  text: string,
+  reservedKeys: Map<string, string>
+): string {
+  const existingValue = reservedKeys.get(baseKey);
+  if (typeof existingValue === "undefined" || existingValue === text) {
+    reservedKeys.set(baseKey, text);
+    return baseKey;
+  }
+
+  const namespacePrefix = formatMessageKey(
+    componentNameToFilename(namespace),
+    "inlang-message-format"
+  );
+  const candidateBase = `${namespacePrefix}_${baseKey}`;
+  let candidate = candidateBase;
+  let counter = 2;
+
+  while (reservedKeys.has(candidate) && reservedKeys.get(candidate) !== text) {
+    candidate = `${candidateBase}_${counter++}`;
+  }
+
+  reservedKeys.set(candidate, text);
+  return candidate;
+}
+
+export function resolveFlatMessageKeyCollisions<T extends { key: string; text: string }>(
+  entries: T[],
+  namespace: string,
+  messagesDir: string,
+  locale: string
+): T[] {
+  const filePath = path.join(messagesDir, `${locale}.json`);
+  const reservedKeys = new Map(Object.entries(readFlatMessageFile(filePath)));
+
+  return entries.map((entry) => ({
+    ...entry,
+    key: reserveCollisionSafeKey(entry.key, namespace, entry.text, reservedKeys),
+  }));
+}

--- a/src/core/i18n/generate-key.ts
+++ b/src/core/i18n/generate-key.ts
@@ -19,6 +19,21 @@ function toCamelCase(str: string): string {
     .join("");
 }
 
+function hashText(text: string): string {
+  let hash = 2_166_136_261;
+
+  for (const character of text) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function containsLettersOrDigits(text: string): boolean {
+  return /[\p{L}\p{N}]/u.test(text);
+}
+
 /**
  * Generate a deterministic key from text.
  * 
@@ -36,17 +51,24 @@ export function generateKey(text: string): string {
   const cleanedText = text.replaceAll(/\{[^}]+\}/g, "");
   
   // Replace apostrophes followed by 's' with just 's' (e.g., "User's" -> "Users")
-  const normalizedText = cleanedText.replaceAll(/'s\b/g, "s");
+  const normalizedText = cleanedText
+    .normalize("NFKD")
+    .replaceAll(/[\u0300-\u036f]/g, "")
+    .replaceAll(/'s\b/g, "s");
   
   // Split into words and take first 4-5 significant words
   const words = normalizedText
-    .replaceAll(/[^\w\s]/g, " ") // Replace special chars (note: \w includes underscores, so this won't replace them)
+    .replaceAll(/[^A-Za-z0-9_\s]/g, " ")
     .replaceAll("_", " ") // Explicitly replace underscores with spaces
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, 5);
   
   if (words.length === 0) {
+    if (containsLettersOrDigits(cleanedText)) {
+      return `text${hashText(cleanedText)}`;
+    }
+
     return "text";
   }
   
@@ -54,6 +76,10 @@ export function generateKey(text: string): string {
   
   // Ensure minimum key length
   if (key.length < 3) {
+    if (containsLettersOrDigits(cleanedText) && !/[A-Za-z0-9]/.test(cleanedText)) {
+      return `text${hashText(cleanedText)}`;
+    }
+
     return "text";
   }
   

--- a/src/core/i18n/output-format.ts
+++ b/src/core/i18n/output-format.ts
@@ -1,0 +1,18 @@
+import { MessagesFormat } from "../../types/config.js";
+
+export const INLANG_MESSAGE_FORMAT_SCHEMA_URL =
+  "https://inlang.com/schema/inlang-message-format";
+
+export function formatMessageKey(
+  key: string,
+  format: MessagesFormat = "json"
+): string {
+  if (format !== "inlang-message-format") {
+    return key;
+  }
+
+  return key
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replaceAll(/[\s-]+/g, "_")
+    .toLowerCase();
+}

--- a/src/core/i18n/write-files.ts
+++ b/src/core/i18n/write-files.ts
@@ -3,21 +3,45 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { MessagesFormat } from "../../types/config.js";
 import { componentNameToFilename } from "./filename-utils.js";
+import {
+    formatMessageKey,
+    INLANG_MESSAGE_FORMAT_SCHEMA_URL,
+} from "./output-format.js";
 
 const DEFAULT_CONFIG_DIR = path.join(os.homedir(), ".i18nizer", "messages");
+
+export interface WriteLocaleFilesOptions {
+    format?: MessagesFormat;
+}
 
 export function writeLocaleFiles(
     namespace: string,
     data: Record<string, Record<string, Record<string, string>>>,
     locales: string[],
-    outputDir?: string
+    outputDir?: string,
+    options: WriteLocaleFilesOptions = {}
 ) {
     const baseDir = outputDir ?? DEFAULT_CONFIG_DIR;
-    
-    // Convert namespace to lowercase-hyphen format for filename
+    const format = options.format ?? "json";
+
+    if (format === "inlang-message-format") {
+        writeInlangMessageFormatFiles(namespace, data, locales, baseDir);
+        return;
+    }
+
+    writeNamespacedJsonFiles(namespace, data, locales, baseDir);
+}
+
+function writeNamespacedJsonFiles(
+    namespace: string,
+    data: Record<string, Record<string, Record<string, string>>>,
+    locales: string[],
+    baseDir: string
+) {
     const filename = componentNameToFilename(namespace);
-    
+
     for (const locale of locales) {
         const content: Record<string, Record<string, string>> = {};
         content[namespace] = {};
@@ -38,5 +62,54 @@ export function writeLocaleFiles(
         fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n");
 
         console.log(chalk.green(`💾 Locale file saved: ${filePath}`));
+    }
+}
+
+function writeInlangMessageFormatFiles(
+    namespace: string,
+    data: Record<string, Record<string, Record<string, string>>>,
+    locales: string[],
+    baseDir: string
+) {
+    const sortedKeys = Object.keys(data[namespace]).sort();
+
+    fs.mkdirSync(baseDir, { recursive: true });
+
+    for (const locale of locales) {
+        const filePath = path.join(baseDir, `${locale}.json`);
+        const existingContent = readInlangMessageFile(filePath);
+
+        for (const key of sortedKeys) {
+            const value = data[namespace][key][locale];
+            if (typeof value !== "undefined") {
+                existingContent[formatMessageKey(key, "inlang-message-format")] = value;
+            }
+        }
+
+        const content: Record<string, string> = {
+            $schema: INLANG_MESSAGE_FORMAT_SCHEMA_URL,
+        };
+
+        for (const key of Object.keys(existingContent).sort()) {
+            content[key] = existingContent[key];
+        }
+
+        fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n");
+        console.log(chalk.green(`💾 Locale file saved: ${filePath}`));
+    }
+}
+
+function readInlangMessageFile(filePath: string): Record<string, string> {
+    if (!fs.existsSync(filePath)) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Record<string, string>;
+        const content = { ...parsed };
+        delete content.$schema;
+        return content;
+    } catch {
+        return {};
     }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,8 +3,14 @@
  */
 
 export type Framework = "custom" | "nextjs" | "react";
-export type I18nLibrary = "custom" | "i18next" | "next-intl" | "react-i18next";
+export type I18nLibrary =
+  | "custom"
+  | "i18next"
+  | "next-intl"
+  | "paraglide-js"
+  | "react-i18next";
 export type AiProvider = "gemini" | "huggingface" | "openai";
+export type MessagesFormat = "inlang-message-format" | "json";
 
 export interface I18nizerConfig {
   ai?: {
@@ -31,7 +37,7 @@ export interface I18nizerConfig {
   i18nLibrary?: I18nLibrary; // Optional field to track detected library
   messages: {
     defaultLocale: string;
-    format: "json";
+    format: MessagesFormat;
     locales: string[];
     path: string;
   };
@@ -154,5 +160,21 @@ export const I18N_LIBRARY_CONFIGS: Record<I18nLibrary, Partial<I18nizerConfig>> 
       },
     },
     i18nLibrary: "react-i18next",
+  },
+  "paraglide-js": {
+    i18n: {
+      function: "m",
+      import: {
+        named: "m",
+        source: "./paraglide/messages.js",
+      },
+    },
+    i18nLibrary: "paraglide-js",
+    messages: {
+      defaultLocale: "en",
+      format: "inlang-message-format",
+      locales: ["en", "es"],
+      path: "messages",
+    },
   },
 };

--- a/test/commands/extract-and-dry-run.test.ts
+++ b/test/commands/extract-and-dry-run.test.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+import yaml from 'js-yaml';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const cliPath = fileURLToPath(new URL('../../bin/run.js', import.meta.url));
+const inlangSchemaUrl = 'https://inlang.com/schema/inlang-message-format';
+
+describe('extract and dry-run integration', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = path.join(os.tmpdir(), `i18nizer-cli-test-${Date.now()}`);
+    fs.mkdirSync(path.join(testDir, 'src'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { force: true, recursive: true });
+    }
+  });
+
+  function runCli(args: string[]) {
+    return spawnSync(process.execPath, [cliPath, ...args], {
+      cwd: testDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    });
+  }
+
+  function writeConfig(config: Record<string, unknown>) {
+    fs.writeFileSync(
+      path.join(testDir, 'i18nizer.config.yml'),
+      yaml.dump(config),
+      'utf8'
+    );
+  }
+
+  function createLegacyConfig() {
+    return {
+      behavior: {
+        allowedFunctions: ['alert', 'confirm', 'prompt'],
+        allowedMemberFunctions: ['toast.error', 'toast.info', 'toast.success', 'toast.warn'],
+        allowedProps: ['alt', 'aria-label', 'aria-placeholder', 'helperText', 'label', 'placeholder', 'text', 'title', 'tooltip'],
+        autoInjectT: true,
+        detectDuplicates: true,
+        opinionatedStructure: true,
+        useAiForKeys: false,
+      },
+      framework: 'react',
+      i18n: {
+        function: 't',
+        import: {
+          named: 'useTranslation',
+          source: 'react-i18next',
+        },
+      },
+      i18nLibrary: 'react-i18next',
+      messages: {
+        defaultLocale: 'en',
+        format: 'json',
+        locales: ['en'],
+        path: 'messages',
+      },
+    };
+  }
+
+  function createParaglideConfig() {
+    return {
+      behavior: {
+        allowedFunctions: ['alert', 'confirm', 'prompt'],
+        allowedMemberFunctions: ['toast.error', 'toast.info', 'toast.success', 'toast.warn'],
+        allowedProps: ['alt', 'aria-label', 'aria-placeholder', 'helperText', 'label', 'placeholder', 'text', 'title', 'tooltip'],
+        autoInjectT: true,
+        detectDuplicates: true,
+        opinionatedStructure: true,
+        useAiForKeys: false,
+      },
+      framework: 'react',
+      i18n: {
+        function: 'm',
+        import: {
+          named: 'm',
+          source: './paraglide/messages.js',
+        },
+      },
+      i18nLibrary: 'paraglide-js',
+      messages: {
+        defaultLocale: 'en',
+        format: 'inlang-message-format',
+        locales: ['en'],
+        path: 'messages',
+      },
+    };
+  }
+
+  it('should run translate --dry-run without AI and without writing project files', () => {
+    const componentPath = path.join(testDir, 'src', 'LoginForm.tsx');
+    const originalSource = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+
+    fs.writeFileSync(componentPath, originalSource, 'utf8');
+    writeConfig(createLegacyConfig());
+
+    const result = runCli(['translate', 'src/LoginForm.tsx', '--dry-run', '--locales', 'en']);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).to.equal(0);
+    expect(fs.readFileSync(componentPath, 'utf8')).to.equal(originalSource);
+    expect(fs.existsSync(path.join(testDir, '.i18nizer'))).to.be.false;
+    expect(fs.existsSync(path.join(testDir, 'messages'))).to.be.false;
+  });
+
+  it('should run extract without AI and write only the default locale in legacy JSON format', () => {
+    const componentPath = path.join(testDir, 'src', 'LoginForm.tsx');
+    const originalSource = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+
+    fs.writeFileSync(componentPath, originalSource, 'utf8');
+    writeConfig(createLegacyConfig());
+
+    const result = runCli(['extract', 'src/LoginForm.tsx', '--locales', 'en,es']);
+    const messagePath = path.join(testDir, 'messages', 'en', 'login-form.json');
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).to.equal(0);
+    expect(fs.readFileSync(componentPath, 'utf8')).to.equal(originalSource);
+    expect(fs.existsSync(messagePath)).to.be.true;
+    expect(JSON.parse(fs.readFileSync(messagePath, 'utf8'))).to.deep.equal({
+      LoginForm: {
+        signIn: 'Sign in',
+      },
+    });
+    expect(fs.existsSync(path.join(testDir, 'messages', 'es'))).to.be.false;
+  });
+
+  it('should run extract without AI and emit Paraglide inlang-message-format files out of the box', () => {
+    const componentPath = path.join(testDir, 'src', 'LoginForm.tsx');
+    const originalSource = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+
+    fs.writeFileSync(componentPath, originalSource, 'utf8');
+    writeConfig(createParaglideConfig());
+
+    const result = runCli(['extract', 'src/LoginForm.tsx', '--locales', 'en,es']);
+    const messagePath = path.join(testDir, 'messages', 'en.json');
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).to.equal(0);
+    expect(fs.readFileSync(componentPath, 'utf8')).to.equal(originalSource);
+    expect(fs.existsSync(messagePath)).to.be.true;
+    expect(JSON.parse(fs.readFileSync(messagePath, 'utf8'))).to.deep.equal({
+      $schema: inlangSchemaUrl,
+      sign_in: 'Sign in',
+    });
+    expect(fs.existsSync(path.join(testDir, 'messages', 'es.json'))).to.be.false;
+    expect(fs.existsSync(path.join(testDir, 'messages', 'en', 'login-form.json'))).to.be.false;
+  });
+});

--- a/test/commands/extract-and-dry-run.test.ts
+++ b/test/commands/extract-and-dry-run.test.ts
@@ -119,6 +119,26 @@ describe('extract and dry-run integration', () => {
     expect(fs.existsSync(path.join(testDir, 'messages'))).to.be.false;
   });
 
+  it('should run extract --dry-run without writing message files', () => {
+    const componentPath = path.join(testDir, 'src', 'LoginForm.tsx');
+    const originalSource = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+
+    fs.writeFileSync(componentPath, originalSource, 'utf8');
+    writeConfig(createParaglideConfig());
+
+    const result = runCli(['extract', 'src/LoginForm.tsx', '--dry-run', '--locales', 'en,es']);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).to.equal(0);
+    expect(result.stdout).to.include('DRY RUN MODE');
+    expect(fs.readFileSync(componentPath, 'utf8')).to.equal(originalSource);
+    expect(fs.existsSync(path.join(testDir, 'messages', 'en.json'))).to.be.false;
+    expect(fs.existsSync(path.join(testDir, 'messages', 'en', 'login-form.json'))).to.be.false;
+  });
+
   it('should run extract without AI and write only the default locale in legacy JSON format', () => {
     const componentPath = path.join(testDir, 'src', 'LoginForm.tsx');
     const originalSource = `
@@ -167,5 +187,103 @@ describe('extract and dry-run integration', () => {
     });
     expect(fs.existsSync(path.join(testDir, 'messages', 'es.json'))).to.be.false;
     expect(fs.existsSync(path.join(testDir, 'messages', 'en', 'login-form.json'))).to.be.false;
+  });
+
+  it('should extract complex probe content without dropping bindings or separators in Paraglide mode', () => {
+    const componentPath = path.join(testDir, 'src', 'Probe.tsx');
+    const source = `
+      import { Button } from "./button";
+
+      export function Probe() {
+        const greeting = "Hello there";
+        const count = 3;
+        const items = ["Apples", "Oranges", "Bananas"];
+
+        return (
+          <div title="Tooltip text" aria-label="Accessible name">
+            <h1>Welcome back</h1>
+            <p>You have {count} new messages</p>
+            <img src="/x.png" alt="A cat sitting" />
+            <input placeholder="Enter your email" />
+            <Button label="Save changes" disabled={false}>Click me</Button>
+            <span>{greeting}</span>
+            <span>{"Literal in braces"}</span>
+            <span>Ends with space </span>
+            <span>  Leading/trailing  </span>
+            <>Fragment text</>
+            {items.map((item) => <li key={item}>{item}</li>)}
+            <p>Line one.<br />Line two.</p>
+            <a href="/x">Read the docs</a>
+            <button onClick={() => alert("Are you sure?")}>Delete</button>
+          </div>
+        );
+      }
+    `;
+
+    fs.writeFileSync(componentPath, source, 'utf8');
+    writeConfig(createParaglideConfig());
+
+    const result = runCli(['extract', 'src/Probe.tsx', '--locales', 'en']);
+    const messagePath = path.join(testDir, 'messages', 'en.json');
+    const output = JSON.parse(fs.readFileSync(messagePath, 'utf8')) as Record<string, string>;
+    const values = Object.values(output);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).to.equal(0);
+    expect(result.stdout).to.include('Provider: deterministic');
+    expect(values).to.include.members([
+      'A cat sitting',
+      'Accessible name',
+      'Apples',
+      'Are you sure?',
+      'Bananas',
+      'Click me',
+      'Delete',
+      'Ends with space ',
+      'Enter your email',
+      'Fragment text',
+      'Hello there',
+      'Line one.\nLine two.',
+      'Literal in braces',
+      'Oranges',
+      'Read the docs',
+      'Save changes',
+      'Tooltip text',
+      'Welcome back',
+      'You have {count} new messages',
+      '  Leading/trailing  ',
+    ]);
+    expect(values).to.not.include('You have');
+    expect(values).to.not.include('new messages');
+  });
+
+  it('should avoid overwriting existing Paraglide keys when later extracts collide', () => {
+    const firstPath = path.join(testDir, 'src', 'FirstButton.tsx');
+    const secondPath = path.join(testDir, 'src', 'SecondButton.tsx');
+
+    fs.writeFileSync(
+      firstPath,
+      'export function FirstButton() { return <button>Save!</button>; }',
+      'utf8'
+    );
+    fs.writeFileSync(
+      secondPath,
+      'export function SecondButton() { return <button>Save?</button>; }',
+      'utf8'
+    );
+    writeConfig(createParaglideConfig());
+
+    const firstRun = runCli(['extract', 'src/FirstButton.tsx', '--locales', 'en']);
+    const secondRun = runCli(['extract', 'src/SecondButton.tsx', '--locales', 'en']);
+    const output = JSON.parse(
+      fs.readFileSync(path.join(testDir, 'messages', 'en.json'), 'utf8')
+    ) as Record<string, string>;
+    const messageEntries = Object.entries(output).filter(([key]) => key !== '$schema');
+    const values = messageEntries.map(([, value]) => value);
+
+    expect(firstRun.status, `${firstRun.stdout}\n${firstRun.stderr}`).to.equal(0);
+    expect(secondRun.status, `${secondRun.stdout}\n${secondRun.stderr}`).to.equal(0);
+    expect(values).to.include('Save!');
+    expect(values).to.include('Save?');
+    expect(new Set(messageEntries.map(([key]) => key)).size).to.equal(messageEntries.length);
   });
 });

--- a/test/core/config/config-manager.test.ts
+++ b/test/core/config/config-manager.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import {
   detectFramework,
+  detectI18nLibrary,
   generateConfig,
   getMessagesDir,
   getProjectDir,
@@ -71,6 +72,24 @@ describe('Config Manager', () => {
     });
   });
 
+  describe('detectI18nLibrary', () => {
+    it('should detect Paraglide JS from package.json', () => {
+      const packageJson = {
+        dependencies: {
+          '@inlang/paraglide-js': '^2.0.0',
+          react: '^18.0.0',
+        },
+      };
+      fs.writeFileSync(
+        path.join(testDir, 'package.json'),
+        JSON.stringify(packageJson)
+      );
+
+      const i18nLibrary = detectI18nLibrary(testDir);
+      expect(i18nLibrary).to.equal('paraglide-js');
+    });
+  });
+
   describe('generateConfig', () => {
     it('should generate Next.js config', () => {
       const config = generateConfig('nextjs');
@@ -92,6 +111,15 @@ describe('Config Manager', () => {
       expect(config.behavior.opinionatedStructure).to.be.true;
       expect(config.behavior.allowedFunctions).to.include('alert');
       expect(config.behavior.allowedProps).to.include('placeholder');
+    });
+
+    it('should generate Paraglide JS config', () => {
+      const config = generateConfig('react', 'paraglide-js' as never);
+      expect(config.i18nLibrary).to.equal('paraglide-js');
+      expect(config.i18n.function).to.equal('m');
+      expect(config.i18n.import.named).to.equal('m');
+      expect(config.i18n.import.source).to.equal('./paraglide/messages.js');
+      expect(config.messages.path).to.equal('messages');
     });
   });
 

--- a/test/core/extract-regressions.test.ts
+++ b/test/core/extract-regressions.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable unicorn/consistent-function-scoping */
+import { expect } from 'chai';
+import { Project, ts } from 'ts-morph';
+
+import { extractTexts } from '../../src/core/ast/extract-text.js';
+
+describe('extract regression coverage', () => {
+  function createTestFile(code: string) {
+    const project = new Project({
+      compilerOptions: {
+        allowJs: true,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.React,
+        skipLibCheck: true,
+        strict: false,
+        target: ts.ScriptTarget.ES2022,
+      },
+      useInMemoryFileSystem: true,
+    });
+
+    return project.createSourceFile('test.tsx', code);
+  }
+
+  it('should extract same-file string bindings used in JSX', () => {
+    const code = `
+      const greeting = "Hello there";
+
+      export function Probe() {
+        return <span>{greeting}</span>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const results = extractTexts(sourceFile);
+    const texts = results.map((result) => result.text);
+
+    expect(texts).to.include('Hello there');
+  });
+
+  it('should extract string arrays that are rendered through JSX maps', () => {
+    const code = `
+      const items = ["Apples", "Oranges", "Bananas"];
+
+      export function Probe() {
+        return <>{items.map((item) => <li key={item}>{item}</li>)}</>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const texts = extractTexts(sourceFile).map((result) => result.text);
+
+    expect(texts).to.include.members(['Apples', 'Oranges', 'Bananas']);
+  });
+
+  it('should extract interpolated JSX sentences as a single message with placeholders', () => {
+    const code = `
+      export function Probe({ count }) {
+        return <p>You have {count} new messages</p>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const results = extractTexts(sourceFile);
+    const sentence = results.find((result) => result.text.includes('You have'));
+    const texts = results.map((result) => result.text);
+
+    expect(sentence).to.exist;
+    expect(sentence!.text).to.equal('You have {count} new messages');
+    expect(sentence!.placeholders).to.deep.equal(['count']);
+    expect(texts).to.not.include('You have');
+    expect(texts).to.not.include('new messages');
+  });
+
+  it('should preserve explicit line breaks across br tags', () => {
+    const code = `
+      export function Probe() {
+        return <p>Line one.<br />Line two.</p>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const results = extractTexts(sourceFile);
+
+    expect(results.map((result) => result.text)).to.include('Line one.\nLine two.');
+  });
+
+  it('should preserve meaningful edge whitespace in JSX text', () => {
+    const code = `
+      export function Probe() {
+        return (
+          <>
+            <span>Ends with space </span>
+            <span>  Leading/trailing  </span>
+          </>
+        );
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const texts = extractTexts(sourceFile).map((result) => result.text);
+
+    expect(texts).to.include('Ends with space ');
+    expect(texts).to.include('  Leading/trailing  ');
+  });
+});

--- a/test/core/generate-key.test.ts
+++ b/test/core/generate-key.test.ts
@@ -55,6 +55,16 @@ describe('Key Generation', () => {
       expect(key).to.equal('text');
     });
 
+    it('should generate deterministic fallback keys for non-Latin text', () => {
+      const key = generateKey('こんにちは世界');
+      expect(key).to.match(/^text[0-9a-f]{8}$/);
+      expect(generateKey('こんにちは世界')).to.equal(key);
+    });
+
+    it('should generate distinct fallback keys for different non-Latin text', () => {
+      expect(generateKey('こんにちは世界')).to.not.equal(generateKey('你好世界'));
+    });
+
     it('should be deterministic - same input produces same output', () => {
       const text = 'Enter your email address';
       const key1 = generateKey(text);

--- a/test/core/paraglide-runtime.test.ts
+++ b/test/core/paraglide-runtime.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable unicorn/consistent-function-scoping */
+import { expect } from 'chai';
+import { Project, ts } from 'ts-morph';
+
+import { extractTexts } from '../../src/core/ast/extract-text.js';
+import { insertUseTranslations } from '../../src/core/ast/insert-user-translations.js';
+import { ReplaceOptions, replaceTempKeysWithT } from '../../src/core/ast/replace-text-with-text.js';
+
+describe('Paraglide runtime support', () => {
+  function createTestFile(code: string) {
+    const project = new Project({
+      compilerOptions: {
+        allowJs: true,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.React,
+        skipLibCheck: true,
+        strict: false,
+        target: ts.ScriptTarget.ES2022,
+      },
+      useInMemoryFileSystem: true,
+    });
+
+    return project.createSourceFile('test.tsx', code);
+  }
+
+  it('should replace JSX text with m.key_name() calls when Paraglide mode is enabled', () => {
+    const code = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const results = extractTexts(sourceFile);
+    const options = {
+      i18nLibrary: 'paraglide-js',
+    } as unknown as ReplaceOptions;
+
+    replaceTempKeysWithT(
+      [
+        {
+          key: 'sign_in',
+          node: results[0].node,
+          placeholders: results[0].placeholders,
+          tempKey: results[0].tempKey,
+        },
+      ],
+      options
+    );
+
+    const updatedCode = sourceFile.getText();
+    expect(updatedCode).to.include('{m.sign_in()}');
+    expect(updatedCode).to.not.include('t("sign_in")');
+  });
+
+  it('should rewrite placeholders to Paraglide message functions with params objects', () => {
+    const code = `
+      export default function WelcomeBanner({ name }) {
+        return <div>{\`Hello \${name}, welcome!\`}</div>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const results = extractTexts(sourceFile);
+    const templateResult = results.find((result) => result.placeholders.length > 0)!;
+    const options = {
+      i18nLibrary: 'paraglide-js',
+    } as unknown as ReplaceOptions;
+
+    replaceTempKeysWithT(
+      [
+        {
+          key: 'greeting_message',
+          node: templateResult.node,
+          placeholders: templateResult.placeholders,
+          tempKey: templateResult.tempKey,
+        },
+      ],
+      options
+    );
+
+    const updatedCode = sourceFile.getText();
+    expect(updatedCode).to.match(/m\.greeting_message\(\{\s*name(?::\s*name)?\s*\}\)/);
+    expect(updatedCode).to.not.include('t("greeting_message"');
+  });
+
+  it('should inject the Paraglide runtime import instead of useTranslations()', () => {
+    const code = `
+      export default function LoginForm() {
+        return <button>Sign in</button>;
+      }
+    `;
+    const sourceFile = createTestFile(code);
+    const injectParaglideImport = insertUseTranslations as unknown as (
+      sourceFile: ReturnType<typeof createTestFile>,
+      namespace: string,
+      options: {
+        i18nLibrary: string;
+        import: {
+          named: string;
+          source: string;
+        };
+      }
+    ) => void;
+
+    injectParaglideImport(sourceFile, 'LoginForm', {
+      i18nLibrary: 'paraglide-js',
+      import: {
+        named: 'm',
+        source: './paraglide/messages.js',
+      },
+    });
+
+    const updatedCode = sourceFile.getText();
+    expect(updatedCode).to.include('import { m } from "./paraglide/messages.js";');
+    expect(updatedCode).to.not.include('useTranslations("LoginForm")');
+  });
+});

--- a/test/core/write-files.test.ts
+++ b/test/core/write-files.test.ts
@@ -224,4 +224,55 @@ describe('writeLocaleFiles - JSON Output Quality', () => {
     // Should be identical
     expect(content1).to.equal(content2);
   });
+
+  it('should write Paraglide inlang-message-format files to messages/{locale}.json', () => {
+    const namespace = 'Checkout';
+    const paraglideData: Record<string, Record<string, Record<string, string>>> = {
+      Checkout: {
+        greeting: {
+          de: 'Hallo {name}!',
+          en: 'Hello {name}!',
+        },
+        welcome_message: {
+          de: 'Willkommen zurück',
+          en: 'Welcome back',
+        },
+      },
+    };
+    const data = {
+      ...paraglideData,
+    };
+    const locales = ['en', 'de'];
+    const outputDir = path.join(testDir, 'messages');
+    const writeParaglideFiles = writeLocaleFiles as unknown as (
+      namespace: string,
+      data: Record<string, Record<string, Record<string, string>>>,
+      locales: string[],
+      outputDir: string,
+      options: {
+        format: 'inlang-message-format';
+      }
+    ) => void;
+
+    writeParaglideFiles(namespace, data, locales, outputDir, {
+      format: 'inlang-message-format',
+    });
+
+    const enPath = path.join(outputDir, 'en.json');
+    const dePath = path.join(outputDir, 'de.json');
+
+    expect(fs.existsSync(enPath)).to.be.true;
+    expect(fs.existsSync(dePath)).to.be.true;
+    expect(JSON.parse(fs.readFileSync(enPath, 'utf8'))).to.deep.equal({
+      $schema: 'https://inlang.com/schema/inlang-message-format',
+      greeting: 'Hello {name}!',
+      welcome_message: 'Welcome back',
+    });
+    expect(JSON.parse(fs.readFileSync(dePath, 'utf8'))).to.deep.equal({
+      $schema: 'https://inlang.com/schema/inlang-message-format',
+      greeting: 'Hallo {name}!',
+      welcome_message: 'Willkommen zurück',
+    });
+    expect(fs.existsSync(path.join(outputDir, 'en', 'checkout.json'))).to.be.false;
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds the requested no-AI extraction flow and Paraglide JS support.

## What changed

- added `paraglide-js` as a supported i18n library
- auto-detects `@inlang/paraglide-js` in `start` / config generation
- added Paraglide defaults:
  - `i18n.function: m`
  - `i18n.import: { named: m, source: "./paraglide/messages.js" }`
  - `messages.format: inlang-message-format`
- made `extract` deterministic by default and independent from AI translations
- `extract` now writes only the default/source locale file
- added inlang message-format output at `messages/{locale}.json` with `$schema`
- made `translate --dry-run` complete without calling AI
- added Paraglide rewrites so generated code uses `m.key_name()`
- updated README for local usage, Paraglide setup, and AI-free extract/dry-run behavior

## Examples

```bash
i18nizer start --framework react --i18n paraglide-js
i18nizer extract src/components/Login.tsx --locales en,es
i18nizer translate src/components/Login.tsx --dry-run --locales en,es
```

Paraglide extract output:

```json
{
  "$schema": "https://inlang.com/schema/inlang-message-format",
  "sign_in": "Sign in"
}
```

Paraglide rewrite shape:

```tsx
import { m } from "./paraglide/messages.js";

<button>{m.sign_in()}</button>
```

## Validation

Latest validated commit: `b78810d`

- `corepack yarn build`
- `corepack yarn test`
- full suite result: `180 passing, 5 pending`
- manual smoke test for `start --i18n paraglide-js`, `extract`, and `translate --dry-run` without API keys